### PR TITLE
Remove FontData::pos and always pass by value

### DIFF
--- a/font-codegen/src/record.rs
+++ b/font-codegen/src/record.rs
@@ -208,7 +208,7 @@ fn generate_from_obj_impl(item: &Record, parse_module: &syn::Path) -> syn::Resul
     Ok(quote! {
         #[cfg(feature = "parsing")]
         impl FromObjRef<#parse_module:: #name #lifetime> for #name {
-            fn from_obj_ref(obj: &#parse_module:: #name, #offset_data_ident: &FontData) -> Self {
+            fn from_obj_ref(obj: &#parse_module:: #name, #offset_data_ident: FontData) -> Self {
                 #name {
                     #( #field_to_owned_stmts, )*
                 }

--- a/font-codegen/src/table.rs
+++ b/font-codegen/src/table.rs
@@ -180,7 +180,7 @@ fn generate_to_owned_impl(item: &Table, parse_module: &syn::Path) -> syn::Result
     Ok(quote! {
         #[cfg(feature = "parsing")]
         impl FromObjRef<#parse_module :: #name<'_>> for #name {
-            fn from_obj_ref(obj: &#parse_module :: #name, _: &FontData) -> Self {
+            fn from_obj_ref(obj: &#parse_module :: #name, _: FontData) -> Self {
                 #maybe_bind_offset_data
                 #name {
                     #( #field_to_owned_stmts, )*
@@ -265,7 +265,7 @@ fn generate_format_from_obj(
     Ok(quote! {
         #[cfg(feature = "parsing")]
         impl FromObjRef<#parse_module:: #name<'_>> for #name {
-            fn from_obj_ref(obj: &#parse_module:: #name, _: &FontData) -> Self {
+            fn from_obj_ref(obj: &#parse_module:: #name, _: FontData) -> Self {
                 use #parse_module::#name as ObjRefType;
                 match obj {
                     #( #to_owned_arms )*

--- a/read-fonts/generated/font.rs
+++ b/read-fonts/generated/font.rs
@@ -108,7 +108,7 @@ impl<'a> SomeTable<'a> for TableDirectory<'a> {
             4usize => Some(Field::new("range_shift", self.range_shift())),
             5usize => Some(Field::new(
                 "table_records",
-                traversal::FieldType::array_of_records(self.table_records(), *self.offset_data()),
+                traversal::FieldType::array_of_records(self.table_records(), self.offset_data()),
             )),
             _ => None,
         }

--- a/read-fonts/generated/generated_cmap.rs
+++ b/read-fonts/generated/generated_cmap.rs
@@ -74,10 +74,7 @@ impl<'a> SomeTable<'a> for Cmap<'a> {
             1usize => Some(Field::new("num_tables", self.num_tables())),
             2usize => Some(Field::new(
                 "encoding_records",
-                traversal::FieldType::array_of_records(
-                    self.encoding_records(),
-                    *self.offset_data(),
-                ),
+                traversal::FieldType::array_of_records(self.encoding_records(), self.offset_data()),
             )),
             _ => None,
         }
@@ -123,7 +120,7 @@ impl EncodingRecord {
     }
 
     /// Attempt to resolve [`subtable_offset`][Self::subtable_offset].
-    pub fn subtable<'a>(&self, data: &FontData<'a>) -> Result<CmapSubtable<'a>, ReadError> {
+    pub fn subtable<'a>(&self, data: FontData<'a>) -> Result<CmapSubtable<'a>, ReadError> {
         self.subtable_offset().resolve(data)
     }
 }
@@ -140,7 +137,7 @@ impl<'a> SomeRecord<'a> for EncodingRecord {
             get_field: Box::new(move |idx, _data| match idx {
                 0usize => Some(Field::new("platform_id", self.platform_id())),
                 1usize => Some(Field::new("encoding_id", self.encoding_id())),
-                2usize => Some(Field::new("subtable_offset", self.subtable(&_data))),
+                2usize => Some(Field::new("subtable_offset", self.subtable(_data))),
                 _ => None,
             }),
             data,
@@ -973,7 +970,7 @@ impl<'a> SomeTable<'a> for Cmap8<'a> {
             4usize => Some(Field::new("num_groups", self.num_groups())),
             5usize => Some(Field::new(
                 "groups",
-                traversal::FieldType::array_of_records(self.groups(), *self.offset_data()),
+                traversal::FieldType::array_of_records(self.groups(), self.offset_data()),
             )),
             _ => None,
         }
@@ -1274,7 +1271,7 @@ impl<'a> SomeTable<'a> for Cmap12<'a> {
             3usize => Some(Field::new("num_groups", self.num_groups())),
             4usize => Some(Field::new(
                 "groups",
-                traversal::FieldType::array_of_records(self.groups(), *self.offset_data()),
+                traversal::FieldType::array_of_records(self.groups(), self.offset_data()),
             )),
             _ => None,
         }
@@ -1390,7 +1387,7 @@ impl<'a> SomeTable<'a> for Cmap13<'a> {
             3usize => Some(Field::new("num_groups", self.num_groups())),
             4usize => Some(Field::new(
                 "groups",
-                traversal::FieldType::array_of_records(self.groups(), *self.offset_data()),
+                traversal::FieldType::array_of_records(self.groups(), self.offset_data()),
             )),
             _ => None,
         }
@@ -1546,7 +1543,7 @@ impl<'a> SomeTable<'a> for Cmap14<'a> {
             )),
             3usize => Some(Field::new(
                 "var_selector",
-                traversal::FieldType::array_of_records(self.var_selector(), *self.offset_data()),
+                traversal::FieldType::array_of_records(self.var_selector(), self.offset_data()),
             )),
             _ => None,
         }
@@ -1680,7 +1677,7 @@ impl<'a> SomeTable<'a> for DefaultUvs<'a> {
             )),
             1usize => Some(Field::new(
                 "ranges",
-                traversal::FieldType::array_of_records(self.ranges(), *self.offset_data()),
+                traversal::FieldType::array_of_records(self.ranges(), self.offset_data()),
             )),
             _ => None,
         }

--- a/read-fonts/generated/generated_gdef.rs
+++ b/read-fonts/generated/generated_gdef.rs
@@ -92,7 +92,7 @@ impl<'a> Gdef<'a> {
 
     /// Attempt to resolve [`glyph_class_def_offset`][Self::glyph_class_def_offset].
     pub fn glyph_class_def(&self) -> Option<Result<ClassDef<'a>, ReadError>> {
-        let data = &self.data;
+        let data = self.data;
         self.glyph_class_def_offset().resolve(data)
     }
 
@@ -105,7 +105,7 @@ impl<'a> Gdef<'a> {
 
     /// Attempt to resolve [`attach_list_offset`][Self::attach_list_offset].
     pub fn attach_list(&self) -> Option<Result<AttachList<'a>, ReadError>> {
-        let data = &self.data;
+        let data = self.data;
         self.attach_list_offset().resolve(data)
     }
 
@@ -118,7 +118,7 @@ impl<'a> Gdef<'a> {
 
     /// Attempt to resolve [`lig_caret_list_offset`][Self::lig_caret_list_offset].
     pub fn lig_caret_list(&self) -> Option<Result<LigCaretList<'a>, ReadError>> {
-        let data = &self.data;
+        let data = self.data;
         self.lig_caret_list_offset().resolve(data)
     }
 
@@ -131,7 +131,7 @@ impl<'a> Gdef<'a> {
 
     /// Attempt to resolve [`mark_attach_class_def_offset`][Self::mark_attach_class_def_offset].
     pub fn mark_attach_class_def(&self) -> Option<Result<ClassDef<'a>, ReadError>> {
-        let data = &self.data;
+        let data = self.data;
         self.mark_attach_class_def_offset().resolve(data)
     }
 
@@ -144,7 +144,7 @@ impl<'a> Gdef<'a> {
 
     /// Attempt to resolve [`mark_glyph_sets_def_offset`][Self::mark_glyph_sets_def_offset].
     pub fn mark_glyph_sets_def(&self) -> Option<Result<MarkGlyphSets<'a>, ReadError>> {
-        let data = &self.data;
+        let data = self.data;
         self.mark_glyph_sets_def_offset()?.resolve(data)
     }
 
@@ -157,7 +157,7 @@ impl<'a> Gdef<'a> {
 
     /// Attempt to resolve [`item_var_store_offset`][Self::item_var_store_offset].
     pub fn item_var_store(&self) -> Option<Result<ClassDef<'a>, ReadError>> {
-        let data = &self.data;
+        let data = self.data;
         self.item_var_store_offset()?.resolve(data)
     }
 }
@@ -286,7 +286,7 @@ impl<'a> AttachList<'a> {
 
     /// Attempt to resolve [`coverage_offset`][Self::coverage_offset].
     pub fn coverage(&self) -> Result<CoverageTable<'a>, ReadError> {
-        let data = &self.data;
+        let data = self.data;
         self.coverage_offset().resolve(data)
     }
 
@@ -307,7 +307,7 @@ impl<'a> AttachList<'a> {
         let data = self.data;
         self.attach_point_offsets()
             .iter()
-            .map(move |off| off.get().resolve(&data))
+            .map(move |off| off.get().resolve(data))
     }
 }
 
@@ -459,7 +459,7 @@ impl<'a> LigCaretList<'a> {
 
     /// Attempt to resolve [`coverage_offset`][Self::coverage_offset].
     pub fn coverage(&self) -> Result<CoverageTable<'a>, ReadError> {
-        let data = &self.data;
+        let data = self.data;
         self.coverage_offset().resolve(data)
     }
 
@@ -480,7 +480,7 @@ impl<'a> LigCaretList<'a> {
         let data = self.data;
         self.lig_glyph_offsets()
             .iter()
-            .map(move |off| off.get().resolve(&data))
+            .map(move |off| off.get().resolve(data))
     }
 }
 
@@ -567,7 +567,7 @@ impl<'a> LigGlyph<'a> {
         let data = self.data;
         self.caret_value_offsets()
             .iter()
-            .map(move |off| off.get().resolve(&data))
+            .map(move |off| off.get().resolve(data))
     }
 }
 
@@ -845,7 +845,7 @@ impl<'a> CaretValueFormat3<'a> {
 
     /// Attempt to resolve [`device_offset`][Self::device_offset].
     pub fn device(&self) -> Result<Device<'a>, ReadError> {
-        let data = &self.data;
+        let data = self.data;
         self.device_offset().resolve(data)
     }
 }
@@ -939,7 +939,7 @@ impl<'a> MarkGlyphSets<'a> {
         let data = self.data;
         self.coverage_offsets()
             .iter()
-            .map(move |off| off.get().resolve(&data))
+            .map(move |off| off.get().resolve(data))
     }
 }
 

--- a/read-fonts/generated/generated_gpos.rs
+++ b/read-fonts/generated/generated_gpos.rs
@@ -75,7 +75,7 @@ impl<'a> Gpos<'a> {
 
     /// Attempt to resolve [`script_list_offset`][Self::script_list_offset].
     pub fn script_list(&self) -> Result<ScriptList<'a>, ReadError> {
-        let data = &self.data;
+        let data = self.data;
         self.script_list_offset().resolve(data)
     }
 
@@ -87,7 +87,7 @@ impl<'a> Gpos<'a> {
 
     /// Attempt to resolve [`feature_list_offset`][Self::feature_list_offset].
     pub fn feature_list(&self) -> Result<FeatureList<'a>, ReadError> {
-        let data = &self.data;
+        let data = self.data;
         self.feature_list_offset().resolve(data)
     }
 
@@ -99,7 +99,7 @@ impl<'a> Gpos<'a> {
 
     /// Attempt to resolve [`lookup_list_offset`][Self::lookup_list_offset].
     pub fn lookup_list(&self) -> Result<PositionLookupList<'a>, ReadError> {
-        let data = &self.data;
+        let data = self.data;
         self.lookup_list_offset().resolve(data)
     }
 
@@ -110,7 +110,7 @@ impl<'a> Gpos<'a> {
 
     /// Attempt to resolve [`feature_variations_offset`][Self::feature_variations_offset].
     pub fn feature_variations(&self) -> Option<Result<FeatureVariations<'a>, ReadError>> {
-        let data = &self.data;
+        let data = self.data;
         self.feature_variations_offset()?.resolve(data)
     }
 }
@@ -456,7 +456,7 @@ impl<'a> AnchorFormat3<'a> {
 
     /// Attempt to resolve [`x_device_offset`][Self::x_device_offset].
     pub fn x_device(&self) -> Option<Result<Device<'a>, ReadError>> {
-        let data = &self.data;
+        let data = self.data;
         self.x_device_offset().resolve(data)
     }
 
@@ -470,7 +470,7 @@ impl<'a> AnchorFormat3<'a> {
 
     /// Attempt to resolve [`y_device_offset`][Self::y_device_offset].
     pub fn y_device(&self) -> Option<Result<Device<'a>, ReadError>> {
-        let data = &self.data;
+        let data = self.data;
         self.y_device_offset().resolve(data)
     }
 }
@@ -558,7 +558,7 @@ impl<'a> SomeTable<'a> for MarkArray<'a> {
             0usize => Some(Field::new("mark_count", self.mark_count())),
             1usize => Some(Field::new(
                 "mark_records",
-                traversal::FieldType::array_of_records(self.mark_records(), *self.offset_data()),
+                traversal::FieldType::array_of_records(self.mark_records(), self.offset_data()),
             )),
             _ => None,
         }
@@ -595,7 +595,7 @@ impl MarkRecord {
     }
 
     /// Attempt to resolve [`mark_anchor_offset`][Self::mark_anchor_offset].
-    pub fn mark_anchor<'a>(&self, data: &FontData<'a>) -> Result<AnchorTable<'a>, ReadError> {
+    pub fn mark_anchor<'a>(&self, data: FontData<'a>) -> Result<AnchorTable<'a>, ReadError> {
         self.mark_anchor_offset().resolve(data)
     }
 }
@@ -611,7 +611,7 @@ impl<'a> SomeRecord<'a> for MarkRecord {
             name: "MarkRecord",
             get_field: Box::new(move |idx, _data| match idx {
                 0usize => Some(Field::new("mark_class", self.mark_class())),
-                1usize => Some(Field::new("mark_anchor_offset", self.mark_anchor(&_data))),
+                1usize => Some(Field::new("mark_anchor_offset", self.mark_anchor(_data))),
                 _ => None,
             }),
             data,
@@ -726,7 +726,7 @@ impl<'a> SinglePosFormat1<'a> {
 
     /// Attempt to resolve [`coverage_offset`][Self::coverage_offset].
     pub fn coverage(&self) -> Result<CoverageTable<'a>, ReadError> {
-        let data = &self.data;
+        let data = self.data;
         self.coverage_offset().resolve(data)
     }
 
@@ -838,7 +838,7 @@ impl<'a> SinglePosFormat2<'a> {
 
     /// Attempt to resolve [`coverage_offset`][Self::coverage_offset].
     pub fn coverage(&self) -> Result<CoverageTable<'a>, ReadError> {
-        let data = &self.data;
+        let data = self.data;
         self.coverage_offset().resolve(data)
     }
 
@@ -877,7 +877,7 @@ impl<'a> SomeTable<'a> for SinglePosFormat2<'a> {
             3usize => Some(Field::new("value_count", self.value_count())),
             4usize => Some(Field::new(
                 "value_records",
-                traversal::FieldType::computed_array(self.value_records(), *self.offset_data()),
+                traversal::FieldType::computed_array(self.value_records(), self.offset_data()),
             )),
             _ => None,
         }
@@ -1008,7 +1008,7 @@ impl<'a> PairPosFormat1<'a> {
 
     /// Attempt to resolve [`coverage_offset`][Self::coverage_offset].
     pub fn coverage(&self) -> Result<CoverageTable<'a>, ReadError> {
-        let data = &self.data;
+        let data = self.data;
         self.coverage_offset().resolve(data)
     }
 
@@ -1044,7 +1044,7 @@ impl<'a> PairPosFormat1<'a> {
         let args = (self.value_format1(), self.value_format2());
         self.pair_set_offsets()
             .iter()
-            .map(move |off| off.get().resolve_with_args(&data, &args))
+            .map(move |off| off.get().resolve_with_args(data, &args))
     }
 }
 
@@ -1164,10 +1164,7 @@ impl<'a> SomeTable<'a> for PairSet<'a> {
             0usize => Some(Field::new("pair_value_count", self.pair_value_count())),
             1usize => Some(Field::new(
                 "pair_value_records",
-                traversal::FieldType::computed_array(
-                    self.pair_value_records(),
-                    *self.offset_data(),
-                ),
+                traversal::FieldType::computed_array(self.pair_value_records(), self.offset_data()),
             )),
             _ => None,
         }
@@ -1351,7 +1348,7 @@ impl<'a> PairPosFormat2<'a> {
 
     /// Attempt to resolve [`coverage_offset`][Self::coverage_offset].
     pub fn coverage(&self) -> Result<CoverageTable<'a>, ReadError> {
-        let data = &self.data;
+        let data = self.data;
         self.coverage_offset().resolve(data)
     }
 
@@ -1378,7 +1375,7 @@ impl<'a> PairPosFormat2<'a> {
 
     /// Attempt to resolve [`class_def1_offset`][Self::class_def1_offset].
     pub fn class_def1(&self) -> Result<ClassDef<'a>, ReadError> {
-        let data = &self.data;
+        let data = self.data;
         self.class_def1_offset().resolve(data)
     }
 
@@ -1391,7 +1388,7 @@ impl<'a> PairPosFormat2<'a> {
 
     /// Attempt to resolve [`class_def2_offset`][Self::class_def2_offset].
     pub fn class_def2(&self) -> Result<ClassDef<'a>, ReadError> {
-        let data = &self.data;
+        let data = self.data;
         self.class_def2_offset().resolve(data)
     }
 
@@ -1440,7 +1437,7 @@ impl<'a> SomeTable<'a> for PairPosFormat2<'a> {
             7usize => Some(Field::new("class2_count", self.class2_count())),
             8usize => Some(Field::new(
                 "class1_records",
-                traversal::FieldType::computed_array(self.class1_records(), *self.offset_data()),
+                traversal::FieldType::computed_array(self.class1_records(), self.offset_data()),
             )),
             _ => None,
         }
@@ -1643,7 +1640,7 @@ impl<'a> CursivePosFormat1<'a> {
 
     /// Attempt to resolve [`coverage_offset`][Self::coverage_offset].
     pub fn coverage(&self) -> Result<CoverageTable<'a>, ReadError> {
-        let data = &self.data;
+        let data = self.data;
         self.coverage_offset().resolve(data)
     }
 
@@ -1674,7 +1671,7 @@ impl<'a> SomeTable<'a> for CursivePosFormat1<'a> {
                 "entry_exit_record",
                 traversal::FieldType::array_of_records(
                     self.entry_exit_record(),
-                    *self.offset_data(),
+                    self.offset_data(),
                 ),
             )),
             _ => None,
@@ -1712,7 +1709,7 @@ impl EntryExitRecord {
     /// Attempt to resolve [`entry_anchor_offset`][Self::entry_anchor_offset].
     pub fn entry_anchor<'a>(
         &self,
-        data: &FontData<'a>,
+        data: FontData<'a>,
     ) -> Option<Result<AnchorTable<'a>, ReadError>> {
         self.entry_anchor_offset().resolve(data)
     }
@@ -1726,7 +1723,7 @@ impl EntryExitRecord {
     /// Attempt to resolve [`exit_anchor_offset`][Self::exit_anchor_offset].
     pub fn exit_anchor<'a>(
         &self,
-        data: &FontData<'a>,
+        data: FontData<'a>,
     ) -> Option<Result<AnchorTable<'a>, ReadError>> {
         self.exit_anchor_offset().resolve(data)
     }
@@ -1742,8 +1739,8 @@ impl<'a> SomeRecord<'a> for EntryExitRecord {
         RecordResolver {
             name: "EntryExitRecord",
             get_field: Box::new(move |idx, _data| match idx {
-                0usize => Some(Field::new("entry_anchor_offset", self.entry_anchor(&_data))),
-                1usize => Some(Field::new("exit_anchor_offset", self.exit_anchor(&_data))),
+                0usize => Some(Field::new("entry_anchor_offset", self.entry_anchor(_data))),
+                1usize => Some(Field::new("exit_anchor_offset", self.exit_anchor(_data))),
                 _ => None,
             }),
             data,
@@ -1819,7 +1816,7 @@ impl<'a> MarkBasePosFormat1<'a> {
 
     /// Attempt to resolve [`mark_coverage_offset`][Self::mark_coverage_offset].
     pub fn mark_coverage(&self) -> Result<CoverageTable<'a>, ReadError> {
-        let data = &self.data;
+        let data = self.data;
         self.mark_coverage_offset().resolve(data)
     }
 
@@ -1832,7 +1829,7 @@ impl<'a> MarkBasePosFormat1<'a> {
 
     /// Attempt to resolve [`base_coverage_offset`][Self::base_coverage_offset].
     pub fn base_coverage(&self) -> Result<CoverageTable<'a>, ReadError> {
-        let data = &self.data;
+        let data = self.data;
         self.base_coverage_offset().resolve(data)
     }
 
@@ -1851,7 +1848,7 @@ impl<'a> MarkBasePosFormat1<'a> {
 
     /// Attempt to resolve [`mark_array_offset`][Self::mark_array_offset].
     pub fn mark_array(&self) -> Result<MarkArray<'a>, ReadError> {
-        let data = &self.data;
+        let data = self.data;
         self.mark_array_offset().resolve(data)
     }
 
@@ -1864,7 +1861,7 @@ impl<'a> MarkBasePosFormat1<'a> {
 
     /// Attempt to resolve [`base_array_offset`][Self::base_array_offset].
     pub fn base_array(&self) -> Result<BaseArray<'a>, ReadError> {
-        let data = &self.data;
+        let data = self.data;
         let args = self.mark_class_count();
         self.base_array_offset().resolve_with_args(data, &args)
     }
@@ -1970,7 +1967,7 @@ impl<'a> SomeTable<'a> for BaseArray<'a> {
             0usize => Some(Field::new("base_count", self.base_count())),
             1usize => Some(Field::new(
                 "base_records",
-                traversal::FieldType::computed_array(self.base_records(), *self.offset_data()),
+                traversal::FieldType::computed_array(self.base_records(), self.offset_data()),
             )),
             _ => None,
         }
@@ -2003,12 +2000,11 @@ impl<'a> BaseRecord<'a> {
 
     pub fn base_anchor(
         &self,
-        data: &FontData<'a>,
+        data: FontData<'a>,
     ) -> impl Iterator<Item = Option<Result<AnchorTable<'a>, ReadError>>> + 'a {
-        let data = *data;
         self.base_anchor_offsets()
             .iter()
-            .map(move |off| off.get().resolve(&data))
+            .map(move |off| off.get().resolve(data))
     }
 }
 
@@ -2045,7 +2041,7 @@ impl<'a> SomeRecord<'a> for BaseRecord<'a> {
                     Field::new(
                         "base_anchor_offsets",
                         FieldType::offset_iter(move || {
-                            Box::new(this.base_anchor(&_data).map(|item| item.into()))
+                            Box::new(this.base_anchor(_data).map(|item| item.into()))
                                 as Box<dyn Iterator<Item = FieldType<'a>> + 'a>
                         }),
                     )
@@ -2125,7 +2121,7 @@ impl<'a> MarkLigPosFormat1<'a> {
 
     /// Attempt to resolve [`mark_coverage_offset`][Self::mark_coverage_offset].
     pub fn mark_coverage(&self) -> Result<CoverageTable<'a>, ReadError> {
-        let data = &self.data;
+        let data = self.data;
         self.mark_coverage_offset().resolve(data)
     }
 
@@ -2138,7 +2134,7 @@ impl<'a> MarkLigPosFormat1<'a> {
 
     /// Attempt to resolve [`ligature_coverage_offset`][Self::ligature_coverage_offset].
     pub fn ligature_coverage(&self) -> Result<CoverageTable<'a>, ReadError> {
-        let data = &self.data;
+        let data = self.data;
         self.ligature_coverage_offset().resolve(data)
     }
 
@@ -2157,7 +2153,7 @@ impl<'a> MarkLigPosFormat1<'a> {
 
     /// Attempt to resolve [`mark_array_offset`][Self::mark_array_offset].
     pub fn mark_array(&self) -> Result<MarkArray<'a>, ReadError> {
-        let data = &self.data;
+        let data = self.data;
         self.mark_array_offset().resolve(data)
     }
 
@@ -2170,7 +2166,7 @@ impl<'a> MarkLigPosFormat1<'a> {
 
     /// Attempt to resolve [`ligature_array_offset`][Self::ligature_array_offset].
     pub fn ligature_array(&self) -> Result<LigatureArray<'a>, ReadError> {
-        let data = &self.data;
+        let data = self.data;
         let args = self.mark_class_count();
         self.ligature_array_offset().resolve_with_args(data, &args)
     }
@@ -2270,7 +2266,7 @@ impl<'a> LigatureArray<'a> {
         let args = self.mark_class_count();
         self.ligature_attach_offsets()
             .iter()
-            .map(move |off| off.get().resolve_with_args(&data, &args))
+            .map(move |off| off.get().resolve_with_args(data, &args))
     }
 
     pub(crate) fn mark_class_count(&self) -> u16 {
@@ -2383,7 +2379,7 @@ impl<'a> SomeTable<'a> for LigatureAttach<'a> {
             0usize => Some(Field::new("component_count", self.component_count())),
             1usize => Some(Field::new(
                 "component_records",
-                traversal::FieldType::computed_array(self.component_records(), *self.offset_data()),
+                traversal::FieldType::computed_array(self.component_records(), self.offset_data()),
             )),
             _ => None,
         }
@@ -2416,12 +2412,11 @@ impl<'a> ComponentRecord<'a> {
 
     pub fn ligature_anchor(
         &self,
-        data: &FontData<'a>,
+        data: FontData<'a>,
     ) -> impl Iterator<Item = Option<Result<AnchorTable<'a>, ReadError>>> + 'a {
-        let data = *data;
         self.ligature_anchor_offsets()
             .iter()
-            .map(move |off| off.get().resolve(&data))
+            .map(move |off| off.get().resolve(data))
     }
 }
 
@@ -2458,7 +2453,7 @@ impl<'a> SomeRecord<'a> for ComponentRecord<'a> {
                     Field::new(
                         "ligature_anchor_offsets",
                         FieldType::offset_iter(move || {
-                            Box::new(this.ligature_anchor(&_data).map(|item| item.into()))
+                            Box::new(this.ligature_anchor(_data).map(|item| item.into()))
                                 as Box<dyn Iterator<Item = FieldType<'a>> + 'a>
                         }),
                     )
@@ -2538,7 +2533,7 @@ impl<'a> MarkMarkPosFormat1<'a> {
 
     /// Attempt to resolve [`mark1_coverage_offset`][Self::mark1_coverage_offset].
     pub fn mark1_coverage(&self) -> Result<CoverageTable<'a>, ReadError> {
-        let data = &self.data;
+        let data = self.data;
         self.mark1_coverage_offset().resolve(data)
     }
 
@@ -2551,7 +2546,7 @@ impl<'a> MarkMarkPosFormat1<'a> {
 
     /// Attempt to resolve [`mark2_coverage_offset`][Self::mark2_coverage_offset].
     pub fn mark2_coverage(&self) -> Result<CoverageTable<'a>, ReadError> {
-        let data = &self.data;
+        let data = self.data;
         self.mark2_coverage_offset().resolve(data)
     }
 
@@ -2570,7 +2565,7 @@ impl<'a> MarkMarkPosFormat1<'a> {
 
     /// Attempt to resolve [`mark1_array_offset`][Self::mark1_array_offset].
     pub fn mark1_array(&self) -> Result<MarkArray<'a>, ReadError> {
-        let data = &self.data;
+        let data = self.data;
         self.mark1_array_offset().resolve(data)
     }
 
@@ -2583,7 +2578,7 @@ impl<'a> MarkMarkPosFormat1<'a> {
 
     /// Attempt to resolve [`mark2_array_offset`][Self::mark2_array_offset].
     pub fn mark2_array(&self) -> Result<Mark2Array<'a>, ReadError> {
-        let data = &self.data;
+        let data = self.data;
         let args = self.mark_class_count();
         self.mark2_array_offset().resolve_with_args(data, &args)
     }
@@ -2689,7 +2684,7 @@ impl<'a> SomeTable<'a> for Mark2Array<'a> {
             0usize => Some(Field::new("mark2_count", self.mark2_count())),
             1usize => Some(Field::new(
                 "mark2_records",
-                traversal::FieldType::computed_array(self.mark2_records(), *self.offset_data()),
+                traversal::FieldType::computed_array(self.mark2_records(), self.offset_data()),
             )),
             _ => None,
         }
@@ -2722,12 +2717,11 @@ impl<'a> Mark2Record<'a> {
 
     pub fn mark2_anchor(
         &self,
-        data: &FontData<'a>,
+        data: FontData<'a>,
     ) -> impl Iterator<Item = Option<Result<AnchorTable<'a>, ReadError>>> + 'a {
-        let data = *data;
         self.mark2_anchor_offsets()
             .iter()
-            .map(move |off| off.get().resolve(&data))
+            .map(move |off| off.get().resolve(data))
     }
 }
 
@@ -2764,7 +2758,7 @@ impl<'a> SomeRecord<'a> for Mark2Record<'a> {
                     Field::new(
                         "mark2_anchor_offsets",
                         FieldType::offset_iter(move || {
-                            Box::new(this.mark2_anchor(&_data).map(|item| item.into()))
+                            Box::new(this.mark2_anchor(_data).map(|item| item.into()))
                                 as Box<dyn Iterator<Item = FieldType<'a>> + 'a>
                         }),
                     )

--- a/read-fonts/generated/generated_hmtx.rs
+++ b/read-fonts/generated/generated_hmtx.rs
@@ -76,7 +76,7 @@ impl<'a> SomeTable<'a> for Hmtx<'a> {
         match idx {
             0usize => Some(Field::new(
                 "h_metrics",
-                traversal::FieldType::array_of_records(self.h_metrics(), *self.offset_data()),
+                traversal::FieldType::array_of_records(self.h_metrics(), self.offset_data()),
             )),
             1usize => Some(Field::new("left_side_bearings", self.left_side_bearings())),
             _ => None,

--- a/read-fonts/generated/generated_layout.rs
+++ b/read-fonts/generated/generated_layout.rs
@@ -63,7 +63,7 @@ impl<'a> SomeTable<'a> for ScriptList<'a> {
             0usize => Some(Field::new("script_count", self.script_count())),
             1usize => Some(Field::new(
                 "script_records",
-                traversal::FieldType::array_of_records(self.script_records(), *self.offset_data()),
+                traversal::FieldType::array_of_records(self.script_records(), self.offset_data()),
             )),
             _ => None,
         }
@@ -100,7 +100,7 @@ impl ScriptRecord {
     }
 
     /// Attempt to resolve [`script_offset`][Self::script_offset].
-    pub fn script<'a>(&self, data: &FontData<'a>) -> Result<Script<'a>, ReadError> {
+    pub fn script<'a>(&self, data: FontData<'a>) -> Result<Script<'a>, ReadError> {
         self.script_offset().resolve(data)
     }
 }
@@ -116,7 +116,7 @@ impl<'a> SomeRecord<'a> for ScriptRecord {
             name: "ScriptRecord",
             get_field: Box::new(move |idx, _data| match idx {
                 0usize => Some(Field::new("script_tag", self.script_tag())),
-                1usize => Some(Field::new("script_offset", self.script(&_data))),
+                1usize => Some(Field::new("script_offset", self.script(_data))),
                 _ => None,
             }),
             data,
@@ -173,7 +173,7 @@ impl<'a> Script<'a> {
 
     /// Attempt to resolve [`default_lang_sys_offset`][Self::default_lang_sys_offset].
     pub fn default_lang_sys(&self) -> Option<Result<LangSys<'a>, ReadError>> {
-        let data = &self.data;
+        let data = self.data;
         self.default_lang_sys_offset().resolve(data)
     }
 
@@ -205,10 +205,7 @@ impl<'a> SomeTable<'a> for Script<'a> {
             1usize => Some(Field::new("lang_sys_count", self.lang_sys_count())),
             2usize => Some(Field::new(
                 "lang_sys_records",
-                traversal::FieldType::array_of_records(
-                    self.lang_sys_records(),
-                    *self.offset_data(),
-                ),
+                traversal::FieldType::array_of_records(self.lang_sys_records(), self.offset_data()),
             )),
             _ => None,
         }
@@ -244,7 +241,7 @@ impl LangSysRecord {
     }
 
     /// Attempt to resolve [`lang_sys_offset`][Self::lang_sys_offset].
-    pub fn lang_sys<'a>(&self, data: &FontData<'a>) -> Result<LangSys<'a>, ReadError> {
+    pub fn lang_sys<'a>(&self, data: FontData<'a>) -> Result<LangSys<'a>, ReadError> {
         self.lang_sys_offset().resolve(data)
     }
 }
@@ -260,7 +257,7 @@ impl<'a> SomeRecord<'a> for LangSysRecord {
             name: "LangSysRecord",
             get_field: Box::new(move |idx, _data| match idx {
                 0usize => Some(Field::new("lang_sys_tag", self.lang_sys_tag())),
-                1usize => Some(Field::new("lang_sys_offset", self.lang_sys(&_data))),
+                1usize => Some(Field::new("lang_sys_offset", self.lang_sys(_data))),
                 _ => None,
             }),
             data,
@@ -421,7 +418,7 @@ impl<'a> SomeTable<'a> for FeatureList<'a> {
             0usize => Some(Field::new("feature_count", self.feature_count())),
             1usize => Some(Field::new(
                 "feature_records",
-                traversal::FieldType::array_of_records(self.feature_records(), *self.offset_data()),
+                traversal::FieldType::array_of_records(self.feature_records(), self.offset_data()),
             )),
             _ => None,
         }
@@ -458,7 +455,7 @@ impl FeatureRecord {
     }
 
     /// Attempt to resolve [`feature_offset`][Self::feature_offset].
-    pub fn feature<'a>(&self, data: &FontData<'a>) -> Result<Feature<'a>, ReadError> {
+    pub fn feature<'a>(&self, data: FontData<'a>) -> Result<Feature<'a>, ReadError> {
         let args = self.feature_tag();
         self.feature_offset().resolve_with_args(data, &args)
     }
@@ -475,7 +472,7 @@ impl<'a> SomeRecord<'a> for FeatureRecord {
             name: "FeatureRecord",
             get_field: Box::new(move |idx, _data| match idx {
                 0usize => Some(Field::new("feature_tag", self.feature_tag())),
-                1usize => Some(Field::new("feature_offset", self.feature(&_data))),
+                1usize => Some(Field::new("feature_offset", self.feature(_data))),
                 _ => None,
             }),
             data,
@@ -541,7 +538,7 @@ impl<'a> Feature<'a> {
 
     /// Attempt to resolve [`feature_params_offset`][Self::feature_params_offset].
     pub fn feature_params(&self) -> Option<Result<FeatureParams<'a>, ReadError>> {
-        let data = &self.data;
+        let data = self.data;
         let args = self.feature_tag();
         self.feature_params_offset().resolve_with_args(data, &args)
     }
@@ -926,7 +923,7 @@ impl<'a> SomeTable<'a> for CoverageFormat2<'a> {
             1usize => Some(Field::new("range_count", self.range_count())),
             2usize => Some(Field::new(
                 "range_records",
-                traversal::FieldType::array_of_records(self.range_records(), *self.offset_data()),
+                traversal::FieldType::array_of_records(self.range_records(), self.offset_data()),
             )),
             _ => None,
         }
@@ -1211,7 +1208,7 @@ impl<'a> SomeTable<'a> for ClassDefFormat2<'a> {
                 "class_range_records",
                 traversal::FieldType::array_of_records(
                     self.class_range_records(),
-                    *self.offset_data(),
+                    self.offset_data(),
                 ),
             )),
             _ => None,
@@ -1426,7 +1423,7 @@ impl<'a> SequenceContextFormat1<'a> {
 
     /// Attempt to resolve [`coverage_offset`][Self::coverage_offset].
     pub fn coverage(&self) -> Result<CoverageTable<'a>, ReadError> {
-        let data = &self.data;
+        let data = self.data;
         self.coverage_offset().resolve(data)
     }
 
@@ -1449,7 +1446,7 @@ impl<'a> SequenceContextFormat1<'a> {
         let data = self.data;
         self.seq_rule_set_offsets()
             .iter()
-            .map(move |off| off.get().resolve(&data))
+            .map(move |off| off.get().resolve(data))
     }
 }
 
@@ -1537,7 +1534,7 @@ impl<'a> SequenceRuleSet<'a> {
         let data = self.data;
         self.seq_rule_offsets()
             .iter()
-            .map(move |off| off.get().resolve(&data))
+            .map(move |off| off.get().resolve(data))
     }
 }
 
@@ -1659,7 +1656,7 @@ impl<'a> SomeTable<'a> for SequenceRule<'a> {
                 "seq_lookup_records",
                 traversal::FieldType::array_of_records(
                     self.seq_lookup_records(),
-                    *self.offset_data(),
+                    self.offset_data(),
                 ),
             )),
             _ => None,
@@ -1744,7 +1741,7 @@ impl<'a> SequenceContextFormat2<'a> {
 
     /// Attempt to resolve [`coverage_offset`][Self::coverage_offset].
     pub fn coverage(&self) -> Result<CoverageTable<'a>, ReadError> {
-        let data = &self.data;
+        let data = self.data;
         self.coverage_offset().resolve(data)
     }
 
@@ -1757,7 +1754,7 @@ impl<'a> SequenceContextFormat2<'a> {
 
     /// Attempt to resolve [`class_def_offset`][Self::class_def_offset].
     pub fn class_def(&self) -> Result<ClassDef<'a>, ReadError> {
-        let data = &self.data;
+        let data = self.data;
         self.class_def_offset().resolve(data)
     }
 
@@ -1780,7 +1777,7 @@ impl<'a> SequenceContextFormat2<'a> {
         let data = self.data;
         self.class_seq_rule_set_offsets()
             .iter()
-            .map(move |off| off.get().resolve(&data))
+            .map(move |off| off.get().resolve(data))
     }
 }
 
@@ -1875,7 +1872,7 @@ impl<'a> ClassSequenceRuleSet<'a> {
         let data = self.data;
         self.class_seq_rule_offsets()
             .iter()
-            .map(move |off| off.get().resolve(&data))
+            .map(move |off| off.get().resolve(data))
     }
 }
 
@@ -2001,7 +1998,7 @@ impl<'a> SomeTable<'a> for ClassSequenceRule<'a> {
                 "seq_lookup_records",
                 traversal::FieldType::array_of_records(
                     self.seq_lookup_records(),
-                    *self.offset_data(),
+                    self.offset_data(),
                 ),
             )),
             _ => None,
@@ -2103,7 +2100,7 @@ impl<'a> SequenceContextFormat3<'a> {
         let data = self.data;
         self.coverage_offsets()
             .iter()
-            .map(move |off| off.get().resolve(&data))
+            .map(move |off| off.get().resolve(data))
     }
 
     /// Array of SequenceLookupRecords
@@ -2137,7 +2134,7 @@ impl<'a> SomeTable<'a> for SequenceContextFormat3<'a> {
                 "seq_lookup_records",
                 traversal::FieldType::array_of_records(
                     self.seq_lookup_records(),
-                    *self.offset_data(),
+                    self.offset_data(),
                 ),
             )),
             _ => None,
@@ -2263,7 +2260,7 @@ impl<'a> ChainedSequenceContextFormat1<'a> {
 
     /// Attempt to resolve [`coverage_offset`][Self::coverage_offset].
     pub fn coverage(&self) -> Result<CoverageTable<'a>, ReadError> {
-        let data = &self.data;
+        let data = self.data;
         self.coverage_offset().resolve(data)
     }
 
@@ -2286,7 +2283,7 @@ impl<'a> ChainedSequenceContextFormat1<'a> {
         let data = self.data;
         self.chained_seq_rule_set_offsets()
             .iter()
-            .map(move |off| off.get().resolve(&data))
+            .map(move |off| off.get().resolve(data))
     }
 }
 
@@ -2380,7 +2377,7 @@ impl<'a> ChainedSequenceRuleSet<'a> {
         let data = self.data;
         self.chained_seq_rule_offsets()
             .iter()
-            .map(move |off| off.get().resolve(&data))
+            .map(move |off| off.get().resolve(data))
     }
 }
 
@@ -2565,7 +2562,7 @@ impl<'a> SomeTable<'a> for ChainedSequenceRule<'a> {
                 "seq_lookup_records",
                 traversal::FieldType::array_of_records(
                     self.seq_lookup_records(),
-                    *self.offset_data(),
+                    self.offset_data(),
                 ),
             )),
             _ => None,
@@ -2660,7 +2657,7 @@ impl<'a> ChainedSequenceContextFormat2<'a> {
 
     /// Attempt to resolve [`coverage_offset`][Self::coverage_offset].
     pub fn coverage(&self) -> Result<CoverageTable<'a>, ReadError> {
-        let data = &self.data;
+        let data = self.data;
         self.coverage_offset().resolve(data)
     }
 
@@ -2673,7 +2670,7 @@ impl<'a> ChainedSequenceContextFormat2<'a> {
 
     /// Attempt to resolve [`backtrack_class_def_offset`][Self::backtrack_class_def_offset].
     pub fn backtrack_class_def(&self) -> Result<ClassDef<'a>, ReadError> {
-        let data = &self.data;
+        let data = self.data;
         self.backtrack_class_def_offset().resolve(data)
     }
 
@@ -2686,7 +2683,7 @@ impl<'a> ChainedSequenceContextFormat2<'a> {
 
     /// Attempt to resolve [`input_class_def_offset`][Self::input_class_def_offset].
     pub fn input_class_def(&self) -> Result<ClassDef<'a>, ReadError> {
-        let data = &self.data;
+        let data = self.data;
         self.input_class_def_offset().resolve(data)
     }
 
@@ -2699,7 +2696,7 @@ impl<'a> ChainedSequenceContextFormat2<'a> {
 
     /// Attempt to resolve [`lookahead_class_def_offset`][Self::lookahead_class_def_offset].
     pub fn lookahead_class_def(&self) -> Result<ClassDef<'a>, ReadError> {
-        let data = &self.data;
+        let data = self.data;
         self.lookahead_class_def_offset().resolve(data)
     }
 
@@ -2722,7 +2719,7 @@ impl<'a> ChainedSequenceContextFormat2<'a> {
         let data = self.data;
         self.chained_class_seq_rule_set_offsets()
             .iter()
-            .map(move |off| off.get().resolve(&data))
+            .map(move |off| off.get().resolve(data))
     }
 }
 
@@ -2825,7 +2822,7 @@ impl<'a> ChainedClassSequenceRuleSet<'a> {
         let data = self.data;
         self.chained_class_seq_rule_offsets()
             .iter()
-            .map(move |off| off.get().resolve(&data))
+            .map(move |off| off.get().resolve(data))
     }
 }
 
@@ -3011,7 +3008,7 @@ impl<'a> SomeTable<'a> for ChainedClassSequenceRule<'a> {
                 "seq_lookup_records",
                 traversal::FieldType::array_of_records(
                     self.seq_lookup_records(),
-                    *self.offset_data(),
+                    self.offset_data(),
                 ),
             )),
             _ => None,
@@ -3136,7 +3133,7 @@ impl<'a> ChainedSequenceContextFormat3<'a> {
         let data = self.data;
         self.backtrack_coverage_offsets()
             .iter()
-            .map(move |off| off.get().resolve(&data))
+            .map(move |off| off.get().resolve(data))
     }
 
     /// Number of glyphs in the input sequence
@@ -3157,7 +3154,7 @@ impl<'a> ChainedSequenceContextFormat3<'a> {
         let data = self.data;
         self.input_coverage_offsets()
             .iter()
-            .map(move |off| off.get().resolve(&data))
+            .map(move |off| off.get().resolve(data))
     }
 
     /// Number of glyphs in the lookahead sequence
@@ -3178,7 +3175,7 @@ impl<'a> ChainedSequenceContextFormat3<'a> {
         let data = self.data;
         self.lookahead_coverage_offsets()
             .iter()
-            .map(move |off| off.get().resolve(&data))
+            .map(move |off| off.get().resolve(data))
     }
 
     /// Number of SequenceLookupRecords
@@ -3246,7 +3243,7 @@ impl<'a> SomeTable<'a> for ChainedSequenceContextFormat3<'a> {
                 "seq_lookup_records",
                 traversal::FieldType::array_of_records(
                     self.seq_lookup_records(),
-                    *self.offset_data(),
+                    self.offset_data(),
                 ),
             )),
             _ => None,
@@ -3608,7 +3605,7 @@ impl<'a> SomeTable<'a> for FeatureVariations<'a> {
                 "feature_variation_records",
                 traversal::FieldType::array_of_records(
                     self.feature_variation_records(),
-                    *self.offset_data(),
+                    self.offset_data(),
                 ),
             )),
             _ => None,
@@ -3644,7 +3641,7 @@ impl FeatureVariationRecord {
     }
 
     /// Attempt to resolve [`condition_set_offset`][Self::condition_set_offset].
-    pub fn condition_set<'a>(&self, data: &FontData<'a>) -> Result<ConditionSet<'a>, ReadError> {
+    pub fn condition_set<'a>(&self, data: FontData<'a>) -> Result<ConditionSet<'a>, ReadError> {
         self.condition_set_offset().resolve(data)
     }
 
@@ -3657,7 +3654,7 @@ impl FeatureVariationRecord {
     /// Attempt to resolve [`feature_table_substitution_offset`][Self::feature_table_substitution_offset].
     pub fn feature_table_substitution<'a>(
         &self,
-        data: &FontData<'a>,
+        data: FontData<'a>,
     ) -> Result<FeatureTableSubstitution<'a>, ReadError> {
         self.feature_table_substitution_offset().resolve(data)
     }
@@ -3675,11 +3672,11 @@ impl<'a> SomeRecord<'a> for FeatureVariationRecord {
             get_field: Box::new(move |idx, _data| match idx {
                 0usize => Some(Field::new(
                     "condition_set_offset",
-                    self.condition_set(&_data),
+                    self.condition_set(_data),
                 )),
                 1usize => Some(Field::new(
                     "feature_table_substitution_offset",
-                    self.feature_table_substitution(&_data),
+                    self.feature_table_substitution(_data),
                 )),
                 _ => None,
             }),
@@ -3740,7 +3737,7 @@ impl<'a> ConditionSet<'a> {
         let data = self.data;
         self.condition_offsets()
             .iter()
-            .map(move |off| off.get().resolve(&data))
+            .map(move |off| off.get().resolve(data))
     }
 }
 
@@ -3945,7 +3942,7 @@ impl<'a> SomeTable<'a> for FeatureTableSubstitution<'a> {
             1usize => Some(Field::new("substitution_count", self.substitution_count())),
             2usize => Some(Field::new(
                 "substitutions",
-                traversal::FieldType::array_of_records(self.substitutions(), *self.offset_data()),
+                traversal::FieldType::array_of_records(self.substitutions(), self.offset_data()),
             )),
             _ => None,
         }
@@ -3997,7 +3994,7 @@ impl<'a> SomeRecord<'a> for FeatureTableSubstitutionRecord {
                 0usize => Some(Field::new("feature_index", self.feature_index())),
                 1usize => Some(Field::new(
                     "alternate_feature_offset",
-                    self.alternate_feature(&_data),
+                    self.alternate_feature(_data),
                 )),
                 _ => None,
             }),

--- a/read-fonts/generated/generated_name.rs
+++ b/read-fonts/generated/generated_name.rs
@@ -135,12 +135,12 @@ impl<'a> SomeTable<'a> for Name<'a> {
             )),
             3usize => Some(Field::new(
                 "name_record",
-                traversal::FieldType::array_of_records(self.name_record(), *self.offset_data()),
+                traversal::FieldType::array_of_records(self.name_record(), self.offset_data()),
             )),
             4usize => Some(Field::new("lang_tag_count", self.lang_tag_count())),
             5usize => Some(Field::new(
                 "lang_tag_record",
-                traversal::FieldType::array_of_records(self.lang_tag_record(), *self.offset_data()),
+                traversal::FieldType::array_of_records(self.lang_tag_record(), self.offset_data()),
             )),
             _ => None,
         }

--- a/read-fonts/src/layout.rs
+++ b/read-fonts/src/layout.rs
@@ -34,7 +34,7 @@ impl<'a, T: FontRead<'a>> TypedLookup<'a, T> {
         self.inner
             .subtable_offsets()
             .iter()
-            .map(move |off| off.get().resolve(&data))
+            .map(move |off| off.get().resolve(data))
     }
 }
 
@@ -119,7 +119,7 @@ impl<'a, T: SomeTable<'a> + FontRead<'a> + 'a> SomeTable<'a> for TypedLookup<'a,
 }
 
 impl FeatureTableSubstitutionRecord {
-    pub fn alternate_feature<'a>(&self, data: &FontData<'a>) -> Result<Feature<'a>, ReadError> {
+    pub fn alternate_feature<'a>(&self, data: FontData<'a>) -> Result<Feature<'a>, ReadError> {
         self.alternate_feature_offset()
             .resolve_with_args(data, &Tag::new(b"NULL"))
     }

--- a/read-fonts/src/layout/gpos.rs
+++ b/read-fonts/src/layout/gpos.rs
@@ -72,7 +72,7 @@ impl<'a, T: FontRead<'a>> TypedExtension<'a, T> {
     }
 
     pub fn get(&self) -> Result<T, ReadError> {
-        self.inner.extension_offset().resolve(&self.inner.data)
+        self.inner.extension_offset().resolve(self.inner.data)
     }
 }
 
@@ -89,7 +89,7 @@ impl<'a> PositionLookupList<'a> {
         self.0
             .lookup_offsets()
             .iter()
-            .map(move |off| off.get().resolve(&data))
+            .map(move |off| off.get().resolve(data))
     }
 }
 

--- a/read-fonts/src/offset.rs
+++ b/read-fonts/src/offset.rs
@@ -33,27 +33,27 @@ impl_offset!(Offset32, 4);
 
 /// a (temporary?) helper trait to blanket impl a resolve method for font_types::Offset
 pub trait ResolveOffset {
-    fn resolve<'a, T: FontRead<'a>>(&self, data: &FontData<'a>) -> Result<T, ReadError>;
+    fn resolve<'a, T: FontRead<'a>>(&self, data: FontData<'a>) -> Result<T, ReadError>;
 
     fn resolve_with_args<'a, T: FontReadWithArgs<'a>>(
         &self,
-        data: &FontData<'a>,
+        data: FontData<'a>,
         args: &T::Args,
     ) -> Result<T, ReadError>;
 }
 
 pub trait ResolveNullableOffset {
-    fn resolve<'a, T: FontRead<'a>>(&self, data: &FontData<'a>) -> Option<Result<T, ReadError>>;
+    fn resolve<'a, T: FontRead<'a>>(&self, data: FontData<'a>) -> Option<Result<T, ReadError>>;
 
     fn resolve_with_args<'a, T: FontReadWithArgs<'a>>(
         &self,
-        data: &FontData<'a>,
+        data: FontData<'a>,
         args: &T::Args,
     ) -> Option<Result<T, ReadError>>;
 }
 
 impl<O: Offset> ResolveNullableOffset for Nullable<O> {
-    fn resolve<'a, T: FontRead<'a>>(&self, data: &FontData<'a>) -> Option<Result<T, ReadError>> {
+    fn resolve<'a, T: FontRead<'a>>(&self, data: FontData<'a>) -> Option<Result<T, ReadError>> {
         match self.offset().resolve(data) {
             Ok(thing) => Some(Ok(thing)),
             Err(ReadError::NullOffset) => None,
@@ -63,7 +63,7 @@ impl<O: Offset> ResolveNullableOffset for Nullable<O> {
 
     fn resolve_with_args<'a, T: FontReadWithArgs<'a>>(
         &self,
-        data: &FontData<'a>,
+        data: FontData<'a>,
         args: &T::Args,
     ) -> Option<Result<T, ReadError>> {
         match self.offset().resolve_with_args(data, args) {
@@ -75,7 +75,7 @@ impl<O: Offset> ResolveNullableOffset for Nullable<O> {
 }
 
 impl<O: Offset> ResolveOffset for O {
-    fn resolve<'a, T: FontRead<'a>>(&self, data: &FontData<'a>) -> Result<T, ReadError> {
+    fn resolve<'a, T: FontRead<'a>>(&self, data: FontData<'a>) -> Result<T, ReadError> {
         self.non_null()
             .ok_or(ReadError::NullOffset)
             .and_then(|off| data.split_off(off).ok_or(ReadError::OutOfBounds))
@@ -84,7 +84,7 @@ impl<O: Offset> ResolveOffset for O {
 
     fn resolve_with_args<'a, T: FontReadWithArgs<'a>>(
         &self,
-        data: &FontData<'a>,
+        data: FontData<'a>,
         args: &T::Args,
     ) -> Result<T, ReadError> {
         self.non_null()

--- a/read-fonts/src/table_ref.rs
+++ b/read-fonts/src/table_ref.rs
@@ -41,14 +41,14 @@ pub trait TableInfoWithArgs: Sized + Copy + ReadArgs {
 impl<'a, T> TableRef<'a, T> {
     /// Resolve the provided offset from the start of this table.
     pub fn resolve_offset<O: Offset, R: FontRead<'a>>(&self, offset: O) -> Result<R, ReadError> {
-        offset.resolve(&self.data)
+        offset.resolve(self.data)
     }
 
     /// Return a reference to this table's raw data.
     ///
     /// We use this in the compile crate to resolve offsets.
-    pub fn offset_data(&self) -> &FontData<'a> {
-        &self.data
+    pub fn offset_data(&self) -> FontData<'a> {
+        self.data
     }
 }
 

--- a/write-fonts/generated/generated_gdef.rs
+++ b/write-fonts/generated/generated_gdef.rs
@@ -68,7 +68,7 @@ impl Validate for Gdef {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::gdef::Gdef<'_>> for Gdef {
-    fn from_obj_ref(obj: &read_fonts::layout::gdef::Gdef, _: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::gdef::Gdef, _: FontData) -> Self {
         Gdef {
             glyph_class_def_offset: obj.glyph_class_def().into(),
             attach_list_offset: obj.attach_list().into(),
@@ -149,7 +149,7 @@ impl Validate for AttachList {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::gdef::AttachList<'_>> for AttachList {
-    fn from_obj_ref(obj: &read_fonts::layout::gdef::AttachList, _: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::gdef::AttachList, _: FontData) -> Self {
         AttachList {
             coverage_offset: obj.coverage().into(),
             attach_point_offsets: obj.attach_point().map(|x| x.into()).collect(),
@@ -196,7 +196,7 @@ impl Validate for AttachPoint {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::gdef::AttachPoint<'_>> for AttachPoint {
-    fn from_obj_ref(obj: &read_fonts::layout::gdef::AttachPoint, _: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::gdef::AttachPoint, _: FontData) -> Self {
         AttachPoint {
             point_indices: obj.point_indices().iter().map(|x| x.get()).collect(),
         }
@@ -250,7 +250,7 @@ impl Validate for LigCaretList {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::gdef::LigCaretList<'_>> for LigCaretList {
-    fn from_obj_ref(obj: &read_fonts::layout::gdef::LigCaretList, _: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::gdef::LigCaretList, _: FontData) -> Self {
         LigCaretList {
             coverage_offset: obj.coverage().into(),
             lig_glyph_offsets: obj.lig_glyph().map(|x| x.into()).collect(),
@@ -299,7 +299,7 @@ impl Validate for LigGlyph {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::gdef::LigGlyph<'_>> for LigGlyph {
-    fn from_obj_ref(obj: &read_fonts::layout::gdef::LigGlyph, _: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::gdef::LigGlyph, _: FontData) -> Self {
         LigGlyph {
             caret_value_offsets: obj.caret_value().map(|x| x.into()).collect(),
         }
@@ -346,7 +346,7 @@ impl Validate for CaretValue {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::gdef::CaretValue<'_>> for CaretValue {
-    fn from_obj_ref(obj: &read_fonts::layout::gdef::CaretValue, _: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::gdef::CaretValue, _: FontData) -> Self {
         use read_fonts::layout::gdef::CaretValue as ObjRefType;
         match obj {
             ObjRefType::Format1(item) => CaretValue::Format1(item.to_owned_table()),
@@ -387,7 +387,7 @@ impl Validate for CaretValueFormat1 {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::gdef::CaretValueFormat1<'_>> for CaretValueFormat1 {
-    fn from_obj_ref(obj: &read_fonts::layout::gdef::CaretValueFormat1, _: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::gdef::CaretValueFormat1, _: FontData) -> Self {
         CaretValueFormat1 {
             coordinate: obj.coordinate(),
         }
@@ -426,7 +426,7 @@ impl Validate for CaretValueFormat2 {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::gdef::CaretValueFormat2<'_>> for CaretValueFormat2 {
-    fn from_obj_ref(obj: &read_fonts::layout::gdef::CaretValueFormat2, _: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::gdef::CaretValueFormat2, _: FontData) -> Self {
         CaretValueFormat2 {
             caret_value_point_index: obj.caret_value_point_index(),
         }
@@ -476,7 +476,7 @@ impl Validate for CaretValueFormat3 {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::gdef::CaretValueFormat3<'_>> for CaretValueFormat3 {
-    fn from_obj_ref(obj: &read_fonts::layout::gdef::CaretValueFormat3, _: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::gdef::CaretValueFormat3, _: FontData) -> Self {
         CaretValueFormat3 {
             coordinate: obj.coordinate(),
             device_offset: obj.device().into(),
@@ -527,7 +527,7 @@ impl Validate for MarkGlyphSets {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::gdef::MarkGlyphSets<'_>> for MarkGlyphSets {
-    fn from_obj_ref(obj: &read_fonts::layout::gdef::MarkGlyphSets, _: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::gdef::MarkGlyphSets, _: FontData) -> Self {
         MarkGlyphSets {
             coverage_offsets: obj.coverage().map(|x| x.into()).collect(),
         }

--- a/write-fonts/generated/generated_gpos.rs
+++ b/write-fonts/generated/generated_gpos.rs
@@ -50,7 +50,7 @@ impl Validate for Gpos {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::gpos::Gpos<'_>> for Gpos {
-    fn from_obj_ref(obj: &read_fonts::layout::gpos::Gpos, _: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::gpos::Gpos, _: FontData) -> Self {
         Gpos {
             script_list_offset: obj.script_list().into(),
             feature_list_offset: obj.feature_list().into(),
@@ -109,7 +109,7 @@ impl Validate for AnchorTable {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::gpos::AnchorTable<'_>> for AnchorTable {
-    fn from_obj_ref(obj: &read_fonts::layout::gpos::AnchorTable, _: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::gpos::AnchorTable, _: FontData) -> Self {
         use read_fonts::layout::gpos::AnchorTable as ObjRefType;
         match obj {
             ObjRefType::Format1(item) => AnchorTable::Format1(item.to_owned_table()),
@@ -153,7 +153,7 @@ impl Validate for AnchorFormat1 {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::gpos::AnchorFormat1<'_>> for AnchorFormat1 {
-    fn from_obj_ref(obj: &read_fonts::layout::gpos::AnchorFormat1, _: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::gpos::AnchorFormat1, _: FontData) -> Self {
         AnchorFormat1 {
             x_coordinate: obj.x_coordinate(),
             y_coordinate: obj.y_coordinate(),
@@ -199,7 +199,7 @@ impl Validate for AnchorFormat2 {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::gpos::AnchorFormat2<'_>> for AnchorFormat2 {
-    fn from_obj_ref(obj: &read_fonts::layout::gpos::AnchorFormat2, _: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::gpos::AnchorFormat2, _: FontData) -> Self {
         AnchorFormat2 {
             x_coordinate: obj.x_coordinate(),
             y_coordinate: obj.y_coordinate(),
@@ -262,7 +262,7 @@ impl Validate for AnchorFormat3 {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::gpos::AnchorFormat3<'_>> for AnchorFormat3 {
-    fn from_obj_ref(obj: &read_fonts::layout::gpos::AnchorFormat3, _: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::gpos::AnchorFormat3, _: FontData) -> Self {
         AnchorFormat3 {
             x_coordinate: obj.x_coordinate(),
             y_coordinate: obj.y_coordinate(),
@@ -314,7 +314,7 @@ impl Validate for MarkArray {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::gpos::MarkArray<'_>> for MarkArray {
-    fn from_obj_ref(obj: &read_fonts::layout::gpos::MarkArray, _: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::gpos::MarkArray, _: FontData) -> Self {
         let offset_data = obj.offset_data();
         MarkArray {
             mark_records: obj
@@ -364,7 +364,7 @@ impl Validate for MarkRecord {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::gpos::MarkRecord> for MarkRecord {
-    fn from_obj_ref(obj: &read_fonts::layout::gpos::MarkRecord, offset_data: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::gpos::MarkRecord, offset_data: FontData) -> Self {
         MarkRecord {
             mark_class: obj.mark_class(),
             mark_anchor_offset: obj.mark_anchor(offset_data).into(),
@@ -399,7 +399,7 @@ impl Validate for SinglePos {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::gpos::SinglePos<'_>> for SinglePos {
-    fn from_obj_ref(obj: &read_fonts::layout::gpos::SinglePos, _: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::gpos::SinglePos, _: FontData) -> Self {
         use read_fonts::layout::gpos::SinglePos as ObjRefType;
         match obj {
             ObjRefType::Format1(item) => SinglePos::Format1(item.to_owned_table()),
@@ -450,7 +450,7 @@ impl Validate for SinglePosFormat1 {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::gpos::SinglePosFormat1<'_>> for SinglePosFormat1 {
-    fn from_obj_ref(obj: &read_fonts::layout::gpos::SinglePosFormat1, _: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::gpos::SinglePosFormat1, _: FontData) -> Self {
         let offset_data = obj.offset_data();
         SinglePosFormat1 {
             coverage_offset: obj.coverage().into(),
@@ -508,7 +508,7 @@ impl Validate for SinglePosFormat2 {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::gpos::SinglePosFormat2<'_>> for SinglePosFormat2 {
-    fn from_obj_ref(obj: &read_fonts::layout::gpos::SinglePosFormat2, _: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::gpos::SinglePosFormat2, _: FontData) -> Self {
         let offset_data = obj.offset_data();
         SinglePosFormat2 {
             coverage_offset: obj.coverage().into(),
@@ -559,7 +559,7 @@ impl Validate for PairPos {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::gpos::PairPos<'_>> for PairPos {
-    fn from_obj_ref(obj: &read_fonts::layout::gpos::PairPos, _: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::gpos::PairPos, _: FontData) -> Self {
         use read_fonts::layout::gpos::PairPos as ObjRefType;
         match obj {
             ObjRefType::Format1(item) => PairPos::Format1(item.to_owned_table()),
@@ -618,7 +618,7 @@ impl Validate for PairPosFormat1 {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::gpos::PairPosFormat1<'_>> for PairPosFormat1 {
-    fn from_obj_ref(obj: &read_fonts::layout::gpos::PairPosFormat1, _: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::gpos::PairPosFormat1, _: FontData) -> Self {
         PairPosFormat1 {
             coverage_offset: obj.coverage().into(),
             pair_set_offsets: obj.pair_set().map(|x| x.into()).collect(),
@@ -668,7 +668,7 @@ impl Validate for PairSet {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::gpos::PairSet<'_>> for PairSet {
-    fn from_obj_ref(obj: &read_fonts::layout::gpos::PairSet, _: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::gpos::PairSet, _: FontData) -> Self {
         let offset_data = obj.offset_data();
         PairSet {
             pair_value_records: obj
@@ -711,7 +711,7 @@ impl Validate for PairValueRecord {
 impl FromObjRef<read_fonts::layout::gpos::PairValueRecord> for PairValueRecord {
     fn from_obj_ref(
         obj: &read_fonts::layout::gpos::PairValueRecord,
-        offset_data: &FontData,
+        offset_data: FontData,
     ) -> Self {
         PairValueRecord {
             second_glyph: obj.second_glyph(),
@@ -775,7 +775,7 @@ impl Validate for PairPosFormat2 {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::gpos::PairPosFormat2<'_>> for PairPosFormat2 {
-    fn from_obj_ref(obj: &read_fonts::layout::gpos::PairPosFormat2, _: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::gpos::PairPosFormat2, _: FontData) -> Self {
         let offset_data = obj.offset_data();
         PairPosFormat2 {
             coverage_offset: obj.coverage().into(),
@@ -829,7 +829,7 @@ impl Validate for Class1Record {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::gpos::Class1Record<'_>> for Class1Record {
-    fn from_obj_ref(obj: &read_fonts::layout::gpos::Class1Record, offset_data: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::gpos::Class1Record, offset_data: FontData) -> Self {
         Class1Record {
             class2_records: obj
                 .class2_records()
@@ -862,7 +862,7 @@ impl Validate for Class2Record {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::gpos::Class2Record> for Class2Record {
-    fn from_obj_ref(obj: &read_fonts::layout::gpos::Class2Record, offset_data: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::gpos::Class2Record, offset_data: FontData) -> Self {
         Class2Record {
             value_record1: obj.value_record1().to_owned_obj(offset_data),
             value_record2: obj.value_record2().to_owned_obj(offset_data),
@@ -907,7 +907,7 @@ impl Validate for CursivePosFormat1 {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::gpos::CursivePosFormat1<'_>> for CursivePosFormat1 {
-    fn from_obj_ref(obj: &read_fonts::layout::gpos::CursivePosFormat1, _: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::gpos::CursivePosFormat1, _: FontData) -> Self {
         let offset_data = obj.offset_data();
         CursivePosFormat1 {
             coverage_offset: obj.coverage().into(),
@@ -966,7 +966,7 @@ impl Validate for EntryExitRecord {
 impl FromObjRef<read_fonts::layout::gpos::EntryExitRecord> for EntryExitRecord {
     fn from_obj_ref(
         obj: &read_fonts::layout::gpos::EntryExitRecord,
-        offset_data: &FontData,
+        offset_data: FontData,
     ) -> Self {
         EntryExitRecord {
             entry_anchor_offset: obj.entry_anchor(offset_data).into(),
@@ -1025,7 +1025,7 @@ impl Validate for MarkBasePosFormat1 {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::gpos::MarkBasePosFormat1<'_>> for MarkBasePosFormat1 {
-    fn from_obj_ref(obj: &read_fonts::layout::gpos::MarkBasePosFormat1, _: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::gpos::MarkBasePosFormat1, _: FontData) -> Self {
         MarkBasePosFormat1 {
             mark_coverage_offset: obj.mark_coverage().into(),
             base_coverage_offset: obj.base_coverage().into(),
@@ -1076,7 +1076,7 @@ impl Validate for BaseArray {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::gpos::BaseArray<'_>> for BaseArray {
-    fn from_obj_ref(obj: &read_fonts::layout::gpos::BaseArray, _: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::gpos::BaseArray, _: FontData) -> Self {
         let offset_data = obj.offset_data();
         BaseArray {
             base_records: obj
@@ -1121,7 +1121,7 @@ impl Validate for BaseRecord {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::gpos::BaseRecord<'_>> for BaseRecord {
-    fn from_obj_ref(obj: &read_fonts::layout::gpos::BaseRecord, offset_data: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::gpos::BaseRecord, offset_data: FontData) -> Self {
         BaseRecord {
             base_anchor_offsets: obj.base_anchor(offset_data).map(|x| x.into()).collect(),
         }
@@ -1178,7 +1178,7 @@ impl Validate for MarkLigPosFormat1 {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::gpos::MarkLigPosFormat1<'_>> for MarkLigPosFormat1 {
-    fn from_obj_ref(obj: &read_fonts::layout::gpos::MarkLigPosFormat1, _: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::gpos::MarkLigPosFormat1, _: FontData) -> Self {
         MarkLigPosFormat1 {
             mark_coverage_offset: obj.mark_coverage().into(),
             ligature_coverage_offset: obj.ligature_coverage().into(),
@@ -1231,7 +1231,7 @@ impl Validate for LigatureArray {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::gpos::LigatureArray<'_>> for LigatureArray {
-    fn from_obj_ref(obj: &read_fonts::layout::gpos::LigatureArray, _: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::gpos::LigatureArray, _: FontData) -> Self {
         LigatureArray {
             ligature_attach_offsets: obj.ligature_attach().map(|x| x.into()).collect(),
         }
@@ -1271,7 +1271,7 @@ impl Validate for LigatureAttach {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::gpos::LigatureAttach<'_>> for LigatureAttach {
-    fn from_obj_ref(obj: &read_fonts::layout::gpos::LigatureAttach, _: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::gpos::LigatureAttach, _: FontData) -> Self {
         let offset_data = obj.offset_data();
         LigatureAttach {
             component_records: obj
@@ -1318,7 +1318,7 @@ impl Validate for ComponentRecord {
 impl FromObjRef<read_fonts::layout::gpos::ComponentRecord<'_>> for ComponentRecord {
     fn from_obj_ref(
         obj: &read_fonts::layout::gpos::ComponentRecord,
-        offset_data: &FontData,
+        offset_data: FontData,
     ) -> Self {
         ComponentRecord {
             ligature_anchor_offsets: obj.ligature_anchor(offset_data).map(|x| x.into()).collect(),
@@ -1376,7 +1376,7 @@ impl Validate for MarkMarkPosFormat1 {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::gpos::MarkMarkPosFormat1<'_>> for MarkMarkPosFormat1 {
-    fn from_obj_ref(obj: &read_fonts::layout::gpos::MarkMarkPosFormat1, _: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::gpos::MarkMarkPosFormat1, _: FontData) -> Self {
         MarkMarkPosFormat1 {
             mark1_coverage_offset: obj.mark1_coverage().into(),
             mark2_coverage_offset: obj.mark2_coverage().into(),
@@ -1427,7 +1427,7 @@ impl Validate for Mark2Array {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::gpos::Mark2Array<'_>> for Mark2Array {
-    fn from_obj_ref(obj: &read_fonts::layout::gpos::Mark2Array, _: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::gpos::Mark2Array, _: FontData) -> Self {
         let offset_data = obj.offset_data();
         Mark2Array {
             mark2_records: obj
@@ -1472,7 +1472,7 @@ impl Validate for Mark2Record {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::gpos::Mark2Record<'_>> for Mark2Record {
-    fn from_obj_ref(obj: &read_fonts::layout::gpos::Mark2Record, offset_data: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::gpos::Mark2Record, offset_data: FontData) -> Self {
         Mark2Record {
             mark2_anchor_offsets: obj.mark2_anchor(offset_data).map(|x| x.into()).collect(),
         }

--- a/write-fonts/generated/generated_head.rs
+++ b/write-fonts/generated/generated_head.rs
@@ -74,7 +74,7 @@ impl Validate for Head {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::tables::head::Head<'_>> for Head {
-    fn from_obj_ref(obj: &read_fonts::tables::head::Head, _: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::tables::head::Head, _: FontData) -> Self {
         Head {
             font_revision: obj.font_revision(),
             checksum_adjustment: obj.checksum_adjustment(),

--- a/write-fonts/generated/generated_layout.rs
+++ b/write-fonts/generated/generated_layout.rs
@@ -35,7 +35,7 @@ impl Validate for ScriptList {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::ScriptList<'_>> for ScriptList {
-    fn from_obj_ref(obj: &read_fonts::layout::ScriptList, _: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::ScriptList, _: FontData) -> Self {
         let offset_data = obj.offset_data();
         ScriptList {
             script_records: obj
@@ -85,7 +85,7 @@ impl Validate for ScriptRecord {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::ScriptRecord> for ScriptRecord {
-    fn from_obj_ref(obj: &read_fonts::layout::ScriptRecord, offset_data: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::ScriptRecord, offset_data: FontData) -> Self {
         ScriptRecord {
             script_tag: obj.script_tag(),
             script_offset: obj.script(offset_data).into(),
@@ -130,7 +130,7 @@ impl Validate for Script {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::Script<'_>> for Script {
-    fn from_obj_ref(obj: &read_fonts::layout::Script, _: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::Script, _: FontData) -> Self {
         let offset_data = obj.offset_data();
         Script {
             default_lang_sys_offset: obj.default_lang_sys().into(),
@@ -180,7 +180,7 @@ impl Validate for LangSysRecord {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::LangSysRecord> for LangSysRecord {
-    fn from_obj_ref(obj: &read_fonts::layout::LangSysRecord, offset_data: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::LangSysRecord, offset_data: FontData) -> Self {
         LangSysRecord {
             lang_sys_tag: obj.lang_sys_tag(),
             lang_sys_offset: obj.lang_sys(offset_data).into(),
@@ -222,7 +222,7 @@ impl Validate for LangSys {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::LangSys<'_>> for LangSys {
-    fn from_obj_ref(obj: &read_fonts::layout::LangSys, _: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::LangSys, _: FontData) -> Self {
         LangSys {
             required_feature_index: obj.required_feature_index(),
             feature_indices: obj.feature_indices().iter().map(|x| x.get()).collect(),
@@ -271,7 +271,7 @@ impl Validate for FeatureList {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::FeatureList<'_>> for FeatureList {
-    fn from_obj_ref(obj: &read_fonts::layout::FeatureList, _: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::FeatureList, _: FontData) -> Self {
         let offset_data = obj.offset_data();
         FeatureList {
             feature_records: obj
@@ -321,7 +321,7 @@ impl Validate for FeatureRecord {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::FeatureRecord> for FeatureRecord {
-    fn from_obj_ref(obj: &read_fonts::layout::FeatureRecord, offset_data: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::FeatureRecord, offset_data: FontData) -> Self {
         FeatureRecord {
             feature_tag: obj.feature_tag(),
             feature_offset: obj.feature(offset_data).into(),
@@ -365,7 +365,7 @@ impl Validate for Feature {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::Feature<'_>> for Feature {
-    fn from_obj_ref(obj: &read_fonts::layout::Feature, _: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::Feature, _: FontData) -> Self {
         Feature {
             feature_params_offset: obj.feature_params().into(),
             lookup_list_indices: obj.lookup_list_indices().iter().map(|x| x.get()).collect(),
@@ -406,7 +406,7 @@ impl Validate for CoverageFormat1 {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::CoverageFormat1<'_>> for CoverageFormat1 {
-    fn from_obj_ref(obj: &read_fonts::layout::CoverageFormat1, _: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::CoverageFormat1, _: FontData) -> Self {
         CoverageFormat1 {
             glyph_array: obj.glyph_array().iter().map(|x| x.get()).collect(),
         }
@@ -454,7 +454,7 @@ impl Validate for CoverageFormat2 {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::CoverageFormat2<'_>> for CoverageFormat2 {
-    fn from_obj_ref(obj: &read_fonts::layout::CoverageFormat2, _: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::CoverageFormat2, _: FontData) -> Self {
         let offset_data = obj.offset_data();
         CoverageFormat2 {
             range_records: obj
@@ -501,7 +501,7 @@ impl Validate for RangeRecord {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::RangeRecord> for RangeRecord {
-    fn from_obj_ref(obj: &read_fonts::layout::RangeRecord, _: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::RangeRecord, _: FontData) -> Self {
         RangeRecord {
             start_glyph_id: obj.start_glyph_id(),
             end_glyph_id: obj.end_glyph_id(),
@@ -537,7 +537,7 @@ impl Validate for CoverageTable {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::CoverageTable<'_>> for CoverageTable {
-    fn from_obj_ref(obj: &read_fonts::layout::CoverageTable, _: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::CoverageTable, _: FontData) -> Self {
         use read_fonts::layout::CoverageTable as ObjRefType;
         match obj {
             ObjRefType::Format1(item) => CoverageTable::Format1(item.to_owned_table()),
@@ -589,7 +589,7 @@ impl Validate for ClassDefFormat1 {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::ClassDefFormat1<'_>> for ClassDefFormat1 {
-    fn from_obj_ref(obj: &read_fonts::layout::ClassDefFormat1, _: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::ClassDefFormat1, _: FontData) -> Self {
         ClassDefFormat1 {
             start_glyph_id: obj.start_glyph_id(),
             class_value_array: obj.class_value_array().iter().map(|x| x.get()).collect(),
@@ -638,7 +638,7 @@ impl Validate for ClassDefFormat2 {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::ClassDefFormat2<'_>> for ClassDefFormat2 {
-    fn from_obj_ref(obj: &read_fonts::layout::ClassDefFormat2, _: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::ClassDefFormat2, _: FontData) -> Self {
         let offset_data = obj.offset_data();
         ClassDefFormat2 {
             class_range_records: obj
@@ -689,7 +689,7 @@ impl Validate for ClassRangeRecord {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::ClassRangeRecord> for ClassRangeRecord {
-    fn from_obj_ref(obj: &read_fonts::layout::ClassRangeRecord, _: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::ClassRangeRecord, _: FontData) -> Self {
         ClassRangeRecord {
             start_glyph_id: obj.start_glyph_id(),
             end_glyph_id: obj.end_glyph_id(),
@@ -725,7 +725,7 @@ impl Validate for ClassDef {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::ClassDef<'_>> for ClassDef {
-    fn from_obj_ref(obj: &read_fonts::layout::ClassDef, _: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::ClassDef, _: FontData) -> Self {
         use read_fonts::layout::ClassDef as ObjRefType;
         match obj {
             ObjRefType::Format1(item) => ClassDef::Format1(item.to_owned_table()),
@@ -766,7 +766,7 @@ impl Validate for SequenceLookupRecord {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::SequenceLookupRecord> for SequenceLookupRecord {
-    fn from_obj_ref(obj: &read_fonts::layout::SequenceLookupRecord, _: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::SequenceLookupRecord, _: FontData) -> Self {
         SequenceLookupRecord {
             sequence_index: obj.sequence_index(),
             lookup_list_index: obj.lookup_list_index(),
@@ -813,7 +813,7 @@ impl Validate for SequenceContextFormat1 {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::SequenceContextFormat1<'_>> for SequenceContextFormat1 {
-    fn from_obj_ref(obj: &read_fonts::layout::SequenceContextFormat1, _: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::SequenceContextFormat1, _: FontData) -> Self {
         SequenceContextFormat1 {
             coverage_offset: obj.coverage().into(),
             seq_rule_set_offsets: obj.seq_rule_set().map(|x| x.into()).collect(),
@@ -863,7 +863,7 @@ impl Validate for SequenceRuleSet {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::SequenceRuleSet<'_>> for SequenceRuleSet {
-    fn from_obj_ref(obj: &read_fonts::layout::SequenceRuleSet, _: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::SequenceRuleSet, _: FontData) -> Self {
         SequenceRuleSet {
             seq_rule_offsets: obj.seq_rule().map(|x| x.into()).collect(),
         }
@@ -914,7 +914,7 @@ impl Validate for SequenceRule {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::SequenceRule<'_>> for SequenceRule {
-    fn from_obj_ref(obj: &read_fonts::layout::SequenceRule, _: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::SequenceRule, _: FontData) -> Self {
         let offset_data = obj.offset_data();
         SequenceRule {
             input_sequence: obj.input_sequence().iter().map(|x| x.get()).collect(),
@@ -983,7 +983,7 @@ impl Validate for SequenceContextFormat2 {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::SequenceContextFormat2<'_>> for SequenceContextFormat2 {
-    fn from_obj_ref(obj: &read_fonts::layout::SequenceContextFormat2, _: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::SequenceContextFormat2, _: FontData) -> Self {
         SequenceContextFormat2 {
             coverage_offset: obj.coverage().into(),
             class_def_offset: obj.class_def().into(),
@@ -1034,7 +1034,7 @@ impl Validate for ClassSequenceRuleSet {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::ClassSequenceRuleSet<'_>> for ClassSequenceRuleSet {
-    fn from_obj_ref(obj: &read_fonts::layout::ClassSequenceRuleSet, _: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::ClassSequenceRuleSet, _: FontData) -> Self {
         ClassSequenceRuleSet {
             class_seq_rule_offsets: obj.class_seq_rule().map(|x| x.into()).collect(),
         }
@@ -1087,7 +1087,7 @@ impl Validate for ClassSequenceRule {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::ClassSequenceRule<'_>> for ClassSequenceRule {
-    fn from_obj_ref(obj: &read_fonts::layout::ClassSequenceRule, _: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::ClassSequenceRule, _: FontData) -> Self {
         let offset_data = obj.offset_data();
         ClassSequenceRule {
             input_sequence: obj.input_sequence().iter().map(|x| x.get()).collect(),
@@ -1152,7 +1152,7 @@ impl Validate for SequenceContextFormat3 {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::SequenceContextFormat3<'_>> for SequenceContextFormat3 {
-    fn from_obj_ref(obj: &read_fonts::layout::SequenceContextFormat3, _: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::SequenceContextFormat3, _: FontData) -> Self {
         let offset_data = obj.offset_data();
         SequenceContextFormat3 {
             coverage_offsets: obj.coverage().map(|x| x.into()).collect(),
@@ -1205,7 +1205,7 @@ impl Validate for SequenceContext {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::SequenceContext<'_>> for SequenceContext {
-    fn from_obj_ref(obj: &read_fonts::layout::SequenceContext, _: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::SequenceContext, _: FontData) -> Self {
         use read_fonts::layout::SequenceContext as ObjRefType;
         match obj {
             ObjRefType::Format1(item) => SequenceContext::Format1(item.to_owned_table()),
@@ -1266,7 +1266,7 @@ impl Validate for ChainedSequenceContextFormat1 {
 impl FromObjRef<read_fonts::layout::ChainedSequenceContextFormat1<'_>>
     for ChainedSequenceContextFormat1
 {
-    fn from_obj_ref(obj: &read_fonts::layout::ChainedSequenceContextFormat1, _: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::ChainedSequenceContextFormat1, _: FontData) -> Self {
         ChainedSequenceContextFormat1 {
             coverage_offset: obj.coverage().into(),
             chained_seq_rule_set_offsets: obj.chained_seq_rule_set().map(|x| x.into()).collect(),
@@ -1319,7 +1319,7 @@ impl Validate for ChainedSequenceRuleSet {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::ChainedSequenceRuleSet<'_>> for ChainedSequenceRuleSet {
-    fn from_obj_ref(obj: &read_fonts::layout::ChainedSequenceRuleSet, _: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::ChainedSequenceRuleSet, _: FontData) -> Self {
         ChainedSequenceRuleSet {
             chained_seq_rule_offsets: obj.chained_seq_rule().map(|x| x.into()).collect(),
         }
@@ -1389,7 +1389,7 @@ impl Validate for ChainedSequenceRule {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::ChainedSequenceRule<'_>> for ChainedSequenceRule {
-    fn from_obj_ref(obj: &read_fonts::layout::ChainedSequenceRule, _: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::ChainedSequenceRule, _: FontData) -> Self {
         let offset_data = obj.offset_data();
         ChainedSequenceRule {
             backtrack_sequence: obj.backtrack_sequence().iter().map(|x| x.get()).collect(),
@@ -1477,7 +1477,7 @@ impl Validate for ChainedSequenceContextFormat2 {
 impl FromObjRef<read_fonts::layout::ChainedSequenceContextFormat2<'_>>
     for ChainedSequenceContextFormat2
 {
-    fn from_obj_ref(obj: &read_fonts::layout::ChainedSequenceContextFormat2, _: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::ChainedSequenceContextFormat2, _: FontData) -> Self {
         ChainedSequenceContextFormat2 {
             coverage_offset: obj.coverage().into(),
             backtrack_class_def_offset: obj.backtrack_class_def().into(),
@@ -1538,7 +1538,7 @@ impl Validate for ChainedClassSequenceRuleSet {
 impl FromObjRef<read_fonts::layout::ChainedClassSequenceRuleSet<'_>>
     for ChainedClassSequenceRuleSet
 {
-    fn from_obj_ref(obj: &read_fonts::layout::ChainedClassSequenceRuleSet, _: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::ChainedClassSequenceRuleSet, _: FontData) -> Self {
         ChainedClassSequenceRuleSet {
             chained_class_seq_rule_offsets: obj
                 .chained_class_seq_rule()
@@ -1615,7 +1615,7 @@ impl Validate for ChainedClassSequenceRule {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::ChainedClassSequenceRule<'_>> for ChainedClassSequenceRule {
-    fn from_obj_ref(obj: &read_fonts::layout::ChainedClassSequenceRule, _: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::ChainedClassSequenceRule, _: FontData) -> Self {
         let offset_data = obj.offset_data();
         ChainedClassSequenceRule {
             backtrack_sequence: obj.backtrack_sequence().iter().map(|x| x.get()).collect(),
@@ -1704,7 +1704,7 @@ impl Validate for ChainedSequenceContextFormat3 {
 impl FromObjRef<read_fonts::layout::ChainedSequenceContextFormat3<'_>>
     for ChainedSequenceContextFormat3
 {
-    fn from_obj_ref(obj: &read_fonts::layout::ChainedSequenceContextFormat3, _: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::ChainedSequenceContextFormat3, _: FontData) -> Self {
         let offset_data = obj.offset_data();
         ChainedSequenceContextFormat3 {
             backtrack_coverage_offsets: obj.backtrack_coverage().map(|x| x.into()).collect(),
@@ -1762,7 +1762,7 @@ impl Validate for ChainedSequenceContext {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::ChainedSequenceContext<'_>> for ChainedSequenceContext {
-    fn from_obj_ref(obj: &read_fonts::layout::ChainedSequenceContext, _: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::ChainedSequenceContext, _: FontData) -> Self {
         use read_fonts::layout::ChainedSequenceContext as ObjRefType;
         match obj {
             ObjRefType::Format1(item) => ChainedSequenceContext::Format1(item.to_owned_table()),
@@ -1838,7 +1838,7 @@ impl Validate for Device {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::Device<'_>> for Device {
-    fn from_obj_ref(obj: &read_fonts::layout::Device, _: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::Device, _: FontData) -> Self {
         Device {
             start_size: obj.start_size(),
             end_size: obj.end_size(),
@@ -1885,7 +1885,7 @@ impl Validate for VariationIndex {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::VariationIndex<'_>> for VariationIndex {
-    fn from_obj_ref(obj: &read_fonts::layout::VariationIndex, _: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::VariationIndex, _: FontData) -> Self {
         VariationIndex {
             delta_set_outer_index: obj.delta_set_outer_index(),
             delta_set_inner_index: obj.delta_set_inner_index(),
@@ -1935,7 +1935,7 @@ impl Validate for FeatureVariations {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::FeatureVariations<'_>> for FeatureVariations {
-    fn from_obj_ref(obj: &read_fonts::layout::FeatureVariations, _: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::FeatureVariations, _: FontData) -> Self {
         let offset_data = obj.offset_data();
         FeatureVariations {
             feature_variation_records: obj
@@ -1992,7 +1992,7 @@ impl Validate for FeatureVariationRecord {
 impl FromObjRef<read_fonts::layout::FeatureVariationRecord> for FeatureVariationRecord {
     fn from_obj_ref(
         obj: &read_fonts::layout::FeatureVariationRecord,
-        offset_data: &FontData,
+        offset_data: FontData,
     ) -> Self {
         FeatureVariationRecord {
             condition_set_offset: obj.condition_set(offset_data).into(),
@@ -2032,7 +2032,7 @@ impl Validate for ConditionSet {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::ConditionSet<'_>> for ConditionSet {
-    fn from_obj_ref(obj: &read_fonts::layout::ConditionSet, _: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::ConditionSet, _: FontData) -> Self {
         ConditionSet {
             condition_offsets: obj.condition().map(|x| x.into()).collect(),
         }
@@ -2079,7 +2079,7 @@ impl Validate for ConditionFormat1 {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::ConditionFormat1<'_>> for ConditionFormat1 {
-    fn from_obj_ref(obj: &read_fonts::layout::ConditionFormat1, _: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::ConditionFormat1, _: FontData) -> Self {
         ConditionFormat1 {
             axis_index: obj.axis_index(),
             filter_range_min_value: obj.filter_range_min_value(),
@@ -2129,7 +2129,7 @@ impl Validate for FeatureTableSubstitution {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::FeatureTableSubstitution<'_>> for FeatureTableSubstitution {
-    fn from_obj_ref(obj: &read_fonts::layout::FeatureTableSubstitution, _: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::FeatureTableSubstitution, _: FontData) -> Self {
         let offset_data = obj.offset_data();
         FeatureTableSubstitution {
             substitutions: obj
@@ -2185,7 +2185,7 @@ impl FromObjRef<read_fonts::layout::FeatureTableSubstitutionRecord>
 {
     fn from_obj_ref(
         obj: &read_fonts::layout::FeatureTableSubstitutionRecord,
-        offset_data: &FontData,
+        offset_data: FontData,
     ) -> Self {
         FeatureTableSubstitutionRecord {
             feature_index: obj.feature_index(),
@@ -2244,7 +2244,7 @@ impl Validate for SizeParams {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::SizeParams<'_>> for SizeParams {
-    fn from_obj_ref(obj: &read_fonts::layout::SizeParams, _: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::SizeParams, _: FontData) -> Self {
         SizeParams {
             design_size: obj.design_size(),
             identifier: obj.identifier(),
@@ -2293,7 +2293,7 @@ impl Validate for StylisticSetParams {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::StylisticSetParams<'_>> for StylisticSetParams {
-    fn from_obj_ref(obj: &read_fonts::layout::StylisticSetParams, _: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::StylisticSetParams, _: FontData) -> Self {
         StylisticSetParams {
             ui_name_id: obj.ui_name_id(),
         }
@@ -2363,7 +2363,7 @@ impl Validate for CharacterVariantParams {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::CharacterVariantParams<'_>> for CharacterVariantParams {
-    fn from_obj_ref(obj: &read_fonts::layout::CharacterVariantParams, _: &FontData) -> Self {
+    fn from_obj_ref(obj: &read_fonts::layout::CharacterVariantParams, _: FontData) -> Self {
         CharacterVariantParams {
             feat_ui_label_name_id: obj.feat_ui_label_name_id(),
             feat_ui_tooltip_text_name_id: obj.feat_ui_tooltip_text_name_id(),

--- a/write-fonts/src/from_obj.rs
+++ b/write-fonts/src/from_obj.rs
@@ -9,7 +9,7 @@ use read_fonts::FontData;
 pub trait FromTableRef<T>: FromObjRef<T> {
     fn from_table_ref(from: &T) -> Self {
         let data = FontData::new(&[]);
-        Self::from_obj_ref(from, &data)
+        Self::from_obj_ref(from, data)
     }
 }
 
@@ -25,7 +25,7 @@ pub trait FromTableRef<T>: FromObjRef<T> {
 /// [`validate`]: [crate::Validate::validate]
 pub trait FromObjRef<T: ?Sized>: Sized {
     //type Owned;
-    fn from_obj_ref(from: &T, data: &FontData) -> Self;
+    fn from_obj_ref(from: &T, data: FontData) -> Self;
 }
 
 /// A conversion from a parsed font object type to an owned version, resolving
@@ -34,7 +34,7 @@ pub trait FromObjRef<T: ?Sized>: Sized {
 /// You should avoid implementing this trait manually. Like [`std::convert::Into`],
 /// it is provided as a blanket impl when you implement [`FromObjRef<T>`].
 pub trait ToOwnedObj<T> {
-    fn to_owned_obj(&self, data: &FontData) -> T;
+    fn to_owned_obj(&self, data: FontData) -> T;
 }
 
 /// A conversion from a fully resolveable parsed font table to its owned equivalent.
@@ -48,7 +48,7 @@ impl<U, T> ToOwnedObj<U> for T
 where
     U: FromObjRef<T>,
 {
-    fn to_owned_obj(&self, data: &FontData) -> U {
+    fn to_owned_obj(&self, data: FontData) -> U {
         U::from_obj_ref(self, data)
     }
 }

--- a/write-fonts/src/layout.rs
+++ b/write-fonts/src/layout.rs
@@ -72,7 +72,7 @@ where
     U: FontRead<'a>,
     T: FromTableRef<U> + 'static,
 {
-    fn from_obj_ref(from: &read_fonts::layout::TypedLookup<'a, U>, _data: &FontData) -> Self {
+    fn from_obj_ref(from: &read_fonts::layout::TypedLookup<'a, U>, _data: FontData) -> Self {
         Lookup {
             lookup_flag: from.lookup_flag(),
             mark_filtering_set: from.mark_filtering_set(),
@@ -96,7 +96,7 @@ where
 {
     fn from_obj_ref(
         from: &read_fonts::layout::gpos::TypedExtension<'a, U>,
-        _data: &FontData,
+        _data: FontData,
     ) -> Self {
         ExtensionSubtable {
             extension_offset: from.get().into(),
@@ -157,7 +157,7 @@ impl Validate for FeatureParams {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::FeatureParams<'_>> for FeatureParams {
-    fn from_obj_ref(from: &read_fonts::layout::FeatureParams, data: &FontData) -> Self {
+    fn from_obj_ref(from: &read_fonts::layout::FeatureParams, data: FontData) -> Self {
         use read_fonts::layout::FeatureParams as FromType;
         match from {
             FromType::Size(thing) => Self::Size(SizeParams::from_obj_ref(thing, data)),

--- a/write-fonts/src/layout/gpos.rs
+++ b/write-fonts/src/layout/gpos.rs
@@ -101,7 +101,7 @@ impl Validate for PositionLookup {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::gpos::PositionLookup<'_>> for PositionLookup {
-    fn from_obj_ref(from: &read_fonts::layout::gpos::PositionLookup<'_>, data: &FontData) -> Self {
+    fn from_obj_ref(from: &read_fonts::layout::gpos::PositionLookup<'_>, data: FontData) -> Self {
         use read_fonts::layout::gpos::PositionLookup as FromType;
         match from {
             FromType::Single(lookup) => Self::Single(lookup.to_owned_obj(data)),
@@ -124,7 +124,7 @@ impl FromTableRef<read_fonts::layout::gpos::PositionLookup<'_>> for PositionLook
 impl FromObjRef<read_fonts::layout::gpos::ExtensionSubtable<'_>> for Extension {
     fn from_obj_ref(
         from: &read_fonts::layout::gpos::ExtensionSubtable<'_>,
-        data: &FontData,
+        data: FontData,
     ) -> Self {
         use read_fonts::layout::gpos::ExtensionSubtable as FromType;
         match from {
@@ -170,7 +170,7 @@ impl FontWrite for PositionLookupList {
 impl FromObjRef<read_fonts::layout::gpos::PositionLookupList<'_>> for PositionLookupList {
     fn from_obj_ref(
         from: &read_fonts::layout::gpos::PositionLookupList<'_>,
-        _data: &FontData,
+        _data: FontData,
     ) -> Self {
         PositionLookupList {
             lookup_offsets: from

--- a/write-fonts/src/layout/value_record.rs
+++ b/write-fonts/src/layout/value_record.rs
@@ -92,7 +92,7 @@ impl Validate for ValueRecord {
 
 #[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::gpos::ValueRecord> for ValueRecord {
-    fn from_obj_ref(from: &read_fonts::layout::gpos::ValueRecord, _data: &FontData) -> Self {
+    fn from_obj_ref(from: &read_fonts::layout::gpos::ValueRecord, _data: FontData) -> Self {
         ValueRecord {
             x_placement: from.x_placement.map(|val| val.get()),
             y_placement: from.y_placement.map(|val| val.get()),


### PR DESCRIPTION
In my initial design I had imagined that FontData would track its
position relative to the data root, so that when a parse error occured
we could store the absolute position of that error, which we could use
in debugging.

I never ended up really purusing this, and so the field was superfluous.

In addition to removing it, this moves to always passing FontData by
value; in effect FontData is a transparent wrapper over &'a [u8]. This
means that we can copy it around, and this in turn simplifies some of
our generated code.